### PR TITLE
Add About Page Content

### DIFF
--- a/about.html
+++ b/about.html
@@ -37,8 +37,65 @@
         </header>
 
         <div class="main-content">
+            <h1>About Me</h1>
             <p>
-                This page is under construction! Check back later for updates!
+                I graduated from the University of Colorado at Boulder in 2020 
+                with a B.A. in Physics. While there, I worked in the Begelman 
+                high energy computational astrophysics group under the guidance 
+                of Dr. Bhupendra Mishra, modeling the effect of magnetic field 
+                orientation on black hole accretion disk transport. This work 
+                challenged my programming skills, introduced me to 
+                high-performance computing, and formed the foundation of my 
+                experience with computational physics, inspiring a deep interest 
+                in both computational modeling and astrophysics. 
+            </p>
+            <p>
+                After graduation, I began work as an Applications Engineer at 
+                Vescent Photonics, a company that specialized in the design and
+                manufacture of lasers and optoelectronics for use in cold atom 
+                experiments, quantum computers, and fiber frequency combs. At 
+                Vescent, I developed key skills in electronics, instrumentation,
+                and technical writing and communication. The role provided my  
+                first exposure to engineering practice and precision laboratory 
+                systems, and I stayed with the company for two years.
+            </p>
+            <p>
+                In 2023, I began my graduate studies as a master's student at 
+                the University of Wisconsin-Madison and worked under Dr. Ben 
+                Lindley to develop modeling tools for studying the fusion fuel 
+                cycle. This work led to the development of Tricycle, a 
+                low-fidelity but flexible module for the fuel cycle simulation 
+                code Cyclus and was designed to explore fusion deployment 
+                scenarios and assess global tritium availability under varying 
+                demand. A preliminary version of this work was presented at the 
+                2024 TOFE Conference in Madison, Wisconsin, and a more complete 
+                paper will be published soon.
+            </p>
+            <p>
+                In the summer of 2024, I accepted an internship at Westinghouse 
+                Electric Company and joined the core design team. There, I 
+                worked on the design of PWR core loading patterns that were 
+                capable of accommodating cycle length extensions using 
+                Westinghouse’s Integral Fuel Burnable Absorber (IFBA). The work 
+                focused heavily on reactor physics, core design, and safety 
+                analysis concepts, and was an invaluable experience.
+            </p>
+            <p>
+                After returning to the University of Wisconsin in the fall of 
+                2024, I accepted a position as a Ph.D. student working in the 
+                Computational Nuclear Engineering Research Group (CNERG) under 
+                Dr. Paul Wilson. My current research focuses on enhancing the 
+                front-end realism of Cyclus through the addition of economic 
+                and financial modeling and long-term contracts. My hope is to 
+                use the tools I develop to provide insight into current events 
+                and policy related to the nuclear fuel cycle.
+            </p>
+            <p>
+                Across these experiences, I've become especially interested in 
+                how computational modeling can bridge the gap between technical 
+                innovation and policy implementation. My long-term goal is to 
+                advance open, reproducible tools that make complex energy 
+                decisions more transparent and data-driven.
             </p>
         </div>
         <div class="image-and-quote">


### PR DESCRIPTION
The About page needed some content, so I added some which describes my professional path in a little more detail than is available on my LinkedIn.

Closes #16
Closes #15 
Closes #14 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace the placeholder on `about.html` with an `h1` and detailed biographical content.
> 
> - **Frontend**:
>   - **About page** (`about.html`):
>     - Replace placeholder text with an `h1` and multiple paragraphs detailing education, professional experience, research, internship, Ph.D. work, and interests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c53269148e05aac0f70efdba2d8d493418b63a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->